### PR TITLE
Fixed nonce to work with API keys that used previous library version

### DIFF
--- a/lib/nonce.js
+++ b/lib/nonce.js
@@ -3,7 +3,7 @@
 let nonce = null
 
 module.exports = () => {
-  let now = new Date().getTime()
+  let now = new Date().getTime() * 1000
   nonce = (nonce < now) ? now : nonce + 1
   return nonce
 }


### PR DESCRIPTION
As the title suggests this reverts the nonce logic to multiply the current timestamp with 1000.
The reason for this is that when the `bitfinex-api-node` repository was separated into multiple repositories, a breaking change was made for anyone that used the SDK at version `2.0.0`.

When we updated the SDK to the minor version `2.0.4` all API calls started failing with the `nonce: small` error.

A possible fix is to re-generate the API key and secret, but I think the correct way to do it is to revert the logic back to the old one because this bug isn't very straight forward to debug, and it will take some time for SDK users to figure it out.