### PR TITLE
Fix nonce

### DIFF
--- a/lib/gen_auth_sig.js
+++ b/lib/gen_auth_sig.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const crypto = require('crypto')
-let nonce = Date.now() * 1000
+const getNonce = require('./nonce')
 
 module.exports = (secret, payload = '') => {
+  const nonce = getNonce()
   if (payload.length === 0) {
     payload = `AUTH${nonce}${nonce}`
   }
@@ -16,6 +17,6 @@ module.exports = (secret, payload = '') => {
   return {
     payload,
     sig,
-    nonce: nonce++
+    nonce: getNonce()
   }
 }

--- a/lib/nonce.js
+++ b/lib/nonce.js
@@ -3,7 +3,7 @@
 let nonce = null
 
 module.exports = () => {
-  let now = new Date().getTime()
+  let now = Date.now() * 1000
   nonce = (nonce < now) ? now : nonce + 1
   return nonce
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-util",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Utilities for the Bitfinex node API",
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "BTC"
   ],
   "contributors": [
+    "Ezequiel Wernicke <ezequiel.wernicke@bitfinex.com> (https://www.bitfinex.com)",
     "Josh Rossi <josh@bitfinex.com> (https://www.bitfinex.com)",
     "Cris Mihalache <cris.m@bitfinex.com> (https://www.bitfinex.com)",
     "Robert Kowalski <robert@bitfinex.com> (https://www.bitfinex.com)",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "bfx-api-node-models": "bitfinexcom/bfx-api-node-models",
     "chai": "^3.4.1",
-    "mocha": "^3.4.2",
+    "mocha": "^6.1.4",
     "standard": "^10.0.2"
   },
   "dependencies": {


### PR DESCRIPTION
Nonce on v1/ws1/ws2 was multiply by x1000 keeping keys used for `v1/ws1/ws2` incompatible with `v2`. 
As to fix this there was added a X1000 to nonce module use on `V2`.
As to prevent future errors nonce module is also use in  `v1/ws1/ws2`
