### PR TITLE
Fix path for bfx-api-node-models

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "homepage": "http://bitfinexcom.github.io/bfx-api-node-util/",
   "devDependencies": {
     "babel-eslint": "^10.0.3",
-    "bfx-api-node-models": "^1.1.0",
     "chai": "^4.2.0",
     "mocha": "^6.2.0",
     "standard": "^14.1.0"
@@ -47,6 +46,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-preset-env": "^1.7.0",
+    "bfx-api-node-models": "^1.1.0",
     "bignumber.js": "^6.0.0",
     "copy": "^0.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-util",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Utilities for the Bitfinex node API",
   "engines": {
     "node": ">=7"
@@ -38,7 +38,7 @@
   "homepage": "http://bitfinexcom.github.io/bfx-api-node-util/",
   "devDependencies": {
     "babel-eslint": "^10.0.3",
-    "bfx-api-node-models": "git+http://github.com/bitfinexcom/bfx-api-node-models.git#semver:^1.1.0",
+    "bfx-api-node-models": "^1.1.0",
     "chai": "^4.2.0",
     "mocha": "^6.2.0",
     "standard": "^14.1.0"


### PR DESCRIPTION
Change path for bfx-api-node-models from github to npm

### Description:
Change path for bfx-api-node-models from github to npm

### Breaking changes:
- no

### New features:
- no

### Fixes:
fixes #8

### PR status:
- [ 1.0.5 ] Version bumped
- [ no ] Change-log updated
- [ no ] Tests added or updated
