### PR TITLE
remove res_notification_info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-# 1.0.4
+# 1.0.6
+- remove function res_notification_info
+- fix circular dep error
+
+# 1.0.5
 - add function res_notification_info
 
 # 1.0.3

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const genAuthSig = require('./lib/gen_auth_sig')
 const isSnapshot = require('./lib/is_snapshot')
 const isClass = require('./lib/is_class')
 const padCandles = require('./lib/pad_candles')
-const takeResNotifyInfo = require('./lib/res_notification_info')
 
 module.exports = {
   ...precision,
@@ -14,6 +13,5 @@ module.exports = {
   genAuthSig,
   isSnapshot,
   isClass,
-  padCandles,
-  takeResNotifyInfo
+  padCandles
 }

--- a/lib/res_notification_info.js
+++ b/lib/res_notification_info.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const { Notification } = require('bfx-api-node-models')
-
-module.exports = (data) => {
-  const notification = new Notification(data)
-  return notification.notifyInfo
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-util",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Utilities for the Bitfinex node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Fixes circular dep error. Linked to PR https://github.com/bitfinexcom/bfx-api-node-rest/pull/38

### Breaking changes:
- [x] Removes takeResNotifyInfo from lib. I dont this will cause a problem since I only added this a few days ago.

### New features:
None

### Fixes:
- [x] Circular dep error

### PR status:
- [x] Version bumped
- [x] Change-log updated
