### PR TITLE
Meta: Bump bignumber.js to 9.0.0 to remove dup dep

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.9
+- meta: bump bignumber.js dep to 9.0.0
+
 # 1.0.8
 - nonce: add parallel support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-util",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Utilities for the Bitfinex node API",
   "engines": {
     "node": ">=7"
@@ -50,7 +50,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "bignumber.js": "^6.0.0",
+    "bignumber.js": "^9.0.0",
     "copy": "^0.3.2"
   }
 }


### PR DESCRIPTION
### Description:
Bumps `bignumber.js` to latest `9.0.0` as it is being used elsewhere and was resolving to 2 versions in the `bfx-hf-chart`/`bfx-hf-server` bundles. Side effect will be reduced bundle size in dep repos.

### Breaking changes:
- [x] `bignumber.js` bumped to 9.0.0

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
