### PR TITLE
Fix invalid main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=7"
   },
-  "main": "./dist/index.js",
+  "main": "./index.js",
   "scripts": {
     "lint": "standard",
     "test": "npm run lint && npm run unit",


### PR DESCRIPTION
### Description:
Invalid main entries now raises a deprecation warning and soon will throw an error. For more info check the [deprecation schedule here](https://nodejs.org/api/deprecations.html#DEP0128)

### Fixes:
- [X] DEP0128: modules with an invalid main entry and an index.js file

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
